### PR TITLE
Update to support Gnome 43

### DIFF
--- a/42/metadata.json
+++ b/42/metadata.json
@@ -7,7 +7,8 @@
     "3.38",
     "40",
     "41",
-    "42"
+    "42",
+    "43"
   ], 
   "url": "https://github.com/lxylxy123456/cariboublocker", 
   "uuid": "block-caribou-36@lxylxy123456.ercli.dev", 


### PR DESCRIPTION
Appears to work with no additional changes in Gnome 43, tested with the locally cached version from gnome extensions.